### PR TITLE
fix(check data model): Last reported_at may be null

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub struct Check {
     #[serde(rename = "numDistinctUsers")]
     pub num_distinct_users: u64,
     #[serde(rename = "lastReportedAt")]
-    pub last_reported_at: DateTime<Utc>,
+    pub last_reported_at: Option<DateTime<Utc>>,
     pub reports: Option<Vec<CheckReport>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,9 +217,9 @@ pub struct CheckReport {
     #[serde(rename = "reporterId")]
     pub reporter_id: u64,
     #[serde(rename = "reporterCountryCode")]
-    pub reporter_country_code: String,
+    pub reporter_country_code: Option<String>,
     #[serde(rename = "reporterCountryName")]
-    pub reporter_country_name: String,
+    pub reporter_country_name: Option<String>,
 }
 
 // Verbose flag if `false`, will exclude reports and the country name field.


### PR DESCRIPTION
`last_reported_at` may be null, for example if the IP was never reported.

Before the change:
```
Error retrieving info about 122.22.22.22: Client(reqwest::Error { kind: Decode, source: Error("invalid type: null, expected an RFC 3339 formatted date and time string", line: 1, column: 321) })
```
After:
```
Check { ip_addr: 122.22.22.22, is_public: true, is_whitelisted: None, abuse_confidence_score: 0, country_code: Some("JP"), country_name: Some("Japan"), usage_type: "Fixed Line ISP", isp: "Open Computer Network", domain: Some("ocn.ne.jp"), total_reports: 0, num_distinct_users: 0, last_reported_at: None, reports: Some([]) }
```